### PR TITLE
Reduce indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You will need XCB bindings with the randr extension. On ubuntu you can install t
   - Tiled by default (Binary space partitioning)
   - Supports workspaces
   - Supports multiple displays
-  - Single file (~600 LoC)
+  - Single file (~1000 LoC)
 
 # Using it
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
-extern crate xcb;
 extern crate regex;
+extern crate xcb;
 
-use std::collections::HashMap;
-use xcb::xproto;
-use xcb::randr;
-use std::error::Error;
-use std::cmp::max;
 use regex::Regex;
+use std::cmp::max;
+use std::collections::HashMap;
+use std::error::Error;
 use std::process::Command;
+use xcb::randr;
+use xcb::xproto;
 
 type XmodmapPke = HashMap<u8, Vec<String>>;
 
@@ -17,24 +17,33 @@ fn xmodmap_pke() -> Result<XmodmapPke, Box<dyn Error>> {
     let lines = String::from_utf8(output.stdout)?
         .lines()
         .filter_map(|line| pattern.captures(line))
-        .map(|cap| (cap[1].parse().unwrap(), cap[2].split(" ").map(|s| s.to_string()).collect()))
+        .map(|cap| {
+            (
+                cap[1].parse().unwrap(),
+                cap[2].split(" ").map(|s| s.to_string()).collect(),
+            )
+        })
         .collect::<HashMap<u8, Vec<String>>>();
     Ok(lines)
 }
 
 pub enum Actions {
-    SwitchWindow, CloseWindow, ChangeLayout, ToggleGap
+    SwitchWindow,
+    CloseWindow,
+    ChangeLayout,
+    ToggleGap,
 }
 
 pub enum Meta {
-    Mod1, Mod4
+    Mod1,
+    Mod4,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 enum Layout {
     BSPV,
     Monocle,
-    BSPH
+    BSPH,
 }
 
 type Window = u32;
@@ -120,12 +129,11 @@ fn keycode_to_key(xmodmap_pke: &XmodmapPke, keycode: u8) -> Option<Key> {
         Some(x) => {
             if x.len() > 0 {
                 Some(x[0].to_string())
-            }
-            else {
+            } else {
                 None
             }
-        },
-        None => None
+        }
+        None => None,
     }
 }
 
@@ -138,14 +146,18 @@ fn key_to_keycode(xmodmap_pke: &XmodmapPke, key: &Key) -> Option<u8> {
     None
 }
 
-
-fn unmap_workspace_windows(conn: &xcb::Connection, windows: &mut Vec<Window>, focus: usize, move_window: bool, same_display: bool) -> Option<Window> {
+fn unmap_workspace_windows(
+    conn: &xcb::Connection,
+    windows: &mut Vec<Window>,
+    focus: usize,
+    move_window: bool,
+    same_display: bool,
+) -> Option<Window> {
     let mut window_to_move = None;
     for (i, window) in windows.iter().enumerate() {
         if move_window && i == focus {
             window_to_move = Some(*window);
-        }
-        else {
+        } else {
             if same_display {
                 xcb::unmap_window(conn, *window);
             }
@@ -154,74 +166,123 @@ fn unmap_workspace_windows(conn: &xcb::Connection, windows: &mut Vec<Window>, fo
     window_to_move
 }
 
-fn change_workspace(conn: &xcb::Connection, workspaces: &mut HashMap<WorkspaceName, Workspace>, previous_workspace: WorkspaceName, next_workspace: WorkspaceName, move_window: bool, same_display: bool) -> Result<WorkspaceName, Box<dyn Error>> {
-    let workspace = workspaces.get_mut(&previous_workspace).ok_or("workspace not found")?;
-    let window_to_move = unmap_workspace_windows(conn, &mut workspace.windows, workspace.focus, move_window, same_display);
+fn change_workspace(
+    conn: &xcb::Connection,
+    workspaces: &mut HashMap<WorkspaceName, Workspace>,
+    previous_workspace: WorkspaceName,
+    next_workspace: WorkspaceName,
+    move_window: bool,
+    same_display: bool,
+) -> Result<WorkspaceName, Box<dyn Error>> {
+    let workspace = workspaces
+        .get_mut(&previous_workspace)
+        .ok_or("workspace not found")?;
+    let window_to_move = unmap_workspace_windows(
+        conn,
+        &mut workspace.windows,
+        workspace.focus,
+        move_window,
+        same_display,
+    );
     match window_to_move {
         Some(w) => {
-            workspace.windows.retain( |x| *x != w );
+            workspace.windows.retain(|x| *x != w);
             if workspace.windows.len() > 0 {
                 workspace.focus = workspace.windows.len() - 1;
-            }
-            else {
+            } else {
                 workspace.focus = 0;
             }
-        },
-        None => {},
+        }
+        None => {}
     };
-    let workspace = workspaces.get_mut(&next_workspace).ok_or("workspace not found")?;
+    let workspace = workspaces
+        .get_mut(&next_workspace)
+        .ok_or("workspace not found")?;
     for window in &workspace.windows {
         xcb::map_window(conn, *window);
     }
-    window_to_move.map( 
-        |w| { 
-            workspace.windows.push(w);
-            workspace.focus = workspace.windows.len() - 1;
-        }
-    );
+    window_to_move.map(|w| {
+        workspace.windows.push(w);
+        workspace.focus = workspace.windows.len() - 1;
+    });
     Ok(next_workspace)
 }
 
-    fn geometries_bsp(i: usize, window_count: usize, left: u32, top: u32, width: u32, height: u32, vertical: usize) -> Vec<Geometry> {
-        if window_count == 0 {
-            vec![]
-        }
-        else if window_count == 1 {
-            vec![Geometry(left, top, width, height)]
-        }
-        else if i % 2 == vertical {
-            let mut res = vec![Geometry(left, top, width, height / 2)];
-            res.append(
-                &mut geometries_bsp(i + 1, window_count - 1, left, top + height / 2, width, height / 2, vertical));
-            res
-        }
-        else {
-            let mut res = vec![Geometry(left, top, width / 2, height)];
-            res.append(
-                &mut geometries_bsp(i + 1, window_count - 1, left + width / 2, top, width / 2, height, vertical));
-            res
-        }
+fn geometries_bsp(
+    i: usize,
+    window_count: usize,
+    left: u32,
+    top: u32,
+    width: u32,
+    height: u32,
+    vertical: usize,
+) -> Vec<Geometry> {
+    if window_count == 0 {
+        vec![]
+    } else if window_count == 1 {
+        vec![Geometry(left, top, width, height)]
+    } else if i % 2 == vertical {
+        let mut res = vec![Geometry(left, top, width, height / 2)];
+        res.append(&mut geometries_bsp(
+            i + 1,
+            window_count - 1,
+            left,
+            top + height / 2,
+            width,
+            height / 2,
+            vertical,
+        ));
+        res
+    } else {
+        let mut res = vec![Geometry(left, top, width / 2, height)];
+        res.append(&mut geometries_bsp(
+            i + 1,
+            window_count - 1,
+            left + width / 2,
+            top,
+            width / 2,
+            height,
+            vertical,
+        ));
+        res
     }
+}
 
-    fn window_types_from_list(conn: &xcb::Connection, types_names: &Vec<String>) -> Vec<xcb::Atom> {
-        types_names.into_iter().map(|x| {
+fn window_types_from_list(conn: &xcb::Connection, types_names: &Vec<String>) -> Vec<xcb::Atom> {
+    types_names
+        .into_iter()
+        .map(|x| {
             let name = format!("_NET_WM_WINDOW_TYPE_{}", x.to_uppercase());
-            let res = xcb::intern_atom(&conn, true, name.as_str()).get_reply().map(|x| x.atom());
+            let res = xcb::intern_atom(&conn, true, name.as_str())
+                .get_reply()
+                .map(|x| x.atom());
             res.ok()
-        }
-        ).flatten().collect()
-    }
+        })
+        .flatten()
+        .collect()
+}
 
 impl UmberWM {
-
     pub fn get_displays_geometries(&mut self) -> Result<Vec<Geometry>, Box<dyn Error>> {
         let conn = &self.conn;
         let setup = self.conn.get_setup();
         let screen = setup.roots().nth(0).unwrap();
         let window_dummy = conn.generate_id();
-        xcb::create_window(&conn, 0, window_dummy, screen.root(), 0, 0, 1, 1, 0, 0, 0, &[]);
-        let screen_res_cookie =
-            randr::get_screen_resources(&conn, window_dummy);
+        xcb::create_window(
+            &conn,
+            0,
+            window_dummy,
+            screen.root(),
+            0,
+            0,
+            1,
+            1,
+            0,
+            0,
+            0,
+            &[],
+        );
+        let screen_res_cookie = randr::get_screen_resources(&conn, window_dummy);
         let screen_res_reply = screen_res_cookie.get_reply().unwrap();
         let crtcs = screen_res_reply.crtcs();
 
@@ -234,37 +295,41 @@ impl UmberWM {
         for (i, crtc_cookie) in crtc_cookies.into_iter().enumerate() {
             if let Ok(reply) = crtc_cookie.get_reply() {
                 if reply.width() > 0 {
-                if i != 0 { println!(""); }
+                    if i != 0 {
+                        println!("");
+                    }
                     println!("CRTC[{}] INFO:", i);
                     println!(" x-off\t: {}", reply.x());
                     println!(" y-off\t: {}", reply.y());
                     println!(" width\t: {}", reply.width());
                     println!(" height\t: {}", reply.height());
-                    result.push(Geometry(reply.x() as u32, reply.y() as u32, reply.width() as u32, reply.height() as u32))
+                    result.push(Geometry(
+                        reply.x() as u32,
+                        reply.y() as u32,
+                        reply.width() as u32,
+                        reply.height() as u32,
+                    ))
                 }
             }
         }
         Ok(result)
     }
 
-
-    fn get_display_border(&mut self, display: usize)-> DisplayBorder {
+    fn get_display_border(&mut self, display: usize) -> DisplayBorder {
         let display_border_i = if display >= self.conf.display_borders.len() {
             self.conf.display_borders.len() - 1
-        }
-        else {
+        } else {
             display
         };
         self.conf.display_borders[display_border_i].clone()
     }
-
 
     fn resize_workspace_windows(&mut self, workspace: &Workspace, mut display: usize) {
         let mut non_float_windows = workspace.windows.clone();
         non_float_windows.retain(|w| !self.float_windows.contains(&w));
         let count = non_float_windows.len();
         if count == 0 || self.displays_geometries.len() <= 0 {
-            return
+            return;
         }
         if display >= self.displays_geometries.len() {
             display = self.displays_geometries.len() - 1;
@@ -277,57 +342,81 @@ impl UmberWM {
         let top = display_geometry.1 + display_border.top;
         let gap = if self.conf.with_gap {
             display_border.gap
-        }
-        else {
+        } else {
             0
         };
         let geos = match workspace.layout {
-            Layout::BSPV => {
-                geometries_bsp(0, count, left, top, width, height, 1)},
-            Layout::BSPH => {
-                geometries_bsp(0, count, left, top, width, height, 0)},
-            Layout::Monocle => {
-                geometries_bsp(0, 1, left, top, width, height, 1)},
+            Layout::BSPV => geometries_bsp(0, count, left, top, width, height, 1),
+            Layout::BSPH => geometries_bsp(0, count, left, top, width, height, 0),
+            Layout::Monocle => geometries_bsp(0, 1, left, top, width, height, 1),
         };
         match workspace.layout {
             Layout::BSPV | Layout::BSPH => {
                 for (i, geo) in geos.iter().enumerate() {
                     match non_float_windows.get(i) {
-                        Some(window) => {xcb::configure_window(&self.conn, *window, &[
-                            (xcb::CONFIG_WINDOW_X as u16, geo.0 + gap),
-                            (xcb::CONFIG_WINDOW_Y as u16, geo.1 + gap),
-                            (xcb::CONFIG_WINDOW_WIDTH as u16, geo.2.saturating_sub(2 * self.conf.border.width + 2 * gap)),
-                            (xcb::CONFIG_WINDOW_HEIGHT as u16, geo.3.saturating_sub(2 * self.conf.border.width + 2 * gap)),
-                            (xcb::CONFIG_WINDOW_BORDER_WIDTH as u16, self.conf.border.width),
-                        ]
-                        );
-                        },
+                        Some(window) => {
+                            xcb::configure_window(
+                                &self.conn,
+                                *window,
+                                &[
+                                    (xcb::CONFIG_WINDOW_X as u16, geo.0 + gap),
+                                    (xcb::CONFIG_WINDOW_Y as u16, geo.1 + gap),
+                                    (
+                                        xcb::CONFIG_WINDOW_WIDTH as u16,
+                                        geo.2.saturating_sub(2 * self.conf.border.width + 2 * gap),
+                                    ),
+                                    (
+                                        xcb::CONFIG_WINDOW_HEIGHT as u16,
+                                        geo.3.saturating_sub(2 * self.conf.border.width + 2 * gap),
+                                    ),
+                                    (
+                                        xcb::CONFIG_WINDOW_BORDER_WIDTH as u16,
+                                        self.conf.border.width,
+                                    ),
+                                ],
+                            );
+                        }
                         None => {}
                     }
                 }
             }
-            Layout::Monocle => {
-                match workspace.windows.get(workspace.focus) {
-                    Some(window) => {xcb::configure_window(&self.conn, *window, &[
-                        (xcb::CONFIG_WINDOW_X as u16, geos[0].0 + gap),
-                        (xcb::CONFIG_WINDOW_Y as u16, geos[0].1 + gap),
-                        (xcb::CONFIG_WINDOW_WIDTH as u16, geos[0].2.saturating_sub(2 * self.conf.border.width + 2 * gap)),
-                        (xcb::CONFIG_WINDOW_HEIGHT as u16, geos[0].3.saturating_sub(2 * self.conf.border.width + 2 * gap)),
-                        (xcb::CONFIG_WINDOW_BORDER_WIDTH as u16, self.conf.border.width),
-                        (xcb::CONFIG_WINDOW_STACK_MODE as u16, xcb::STACK_MODE_ABOVE),
-                    ]
+            Layout::Monocle => match workspace.windows.get(workspace.focus) {
+                Some(window) => {
+                    xcb::configure_window(
+                        &self.conn,
+                        *window,
+                        &[
+                            (xcb::CONFIG_WINDOW_X as u16, geos[0].0 + gap),
+                            (xcb::CONFIG_WINDOW_Y as u16, geos[0].1 + gap),
+                            (
+                                xcb::CONFIG_WINDOW_WIDTH as u16,
+                                geos[0]
+                                    .2
+                                    .saturating_sub(2 * self.conf.border.width + 2 * gap),
+                            ),
+                            (
+                                xcb::CONFIG_WINDOW_HEIGHT as u16,
+                                geos[0]
+                                    .3
+                                    .saturating_sub(2 * self.conf.border.width + 2 * gap),
+                            ),
+                            (
+                                xcb::CONFIG_WINDOW_BORDER_WIDTH as u16,
+                                self.conf.border.width,
+                            ),
+                            (xcb::CONFIG_WINDOW_STACK_MODE as u16, xcb::STACK_MODE_ABOVE),
+                        ],
                     );
-                    },
-                    None => {}
                 }
-            }
+                None => {}
+            },
         }
         for (i, _) in workspace.windows.iter().enumerate() {
             match workspace.windows.get(i) {
                 Some(window) => {
                     let _ = self.focus_unfocus(window, i == workspace.focus);
-                },
-                None =>{}
+                }
+                None => {}
             }
         }
     }
@@ -336,114 +425,217 @@ impl UmberWM {
         self.displays_geometries = self.get_displays_geometries().unwrap();
         let screen = self.conn.get_setup().roots().nth(0).unwrap();
         let mod_key = match self.conf.meta {
-             Meta::Mod4 => xcb::MOD_MASK_4,
-             Meta::Mod1 => xcb::MOD_MASK_1
+            Meta::Mod4 => xcb::MOD_MASK_4,
+            Meta::Mod1 => xcb::MOD_MASK_1,
         };
-        self.randr_base = self.conn.get_extension_data(&mut randr::id()).unwrap().first_event();
-        let _ = randr::select_input(&self.conn, screen.root(), randr::NOTIFY_MASK_CRTC_CHANGE as u16)
-            .request_check();
+        self.randr_base = self
+            .conn
+            .get_extension_data(&mut randr::id())
+            .unwrap()
+            .first_event();
+        let _ = randr::select_input(
+            &self.conn,
+            screen.root(),
+            randr::NOTIFY_MASK_CRTC_CHANGE as u16,
+        )
+        .request_check();
         for mod_mask in vec![mod_key, mod_key | xcb::MOD_MASK_SHIFT] {
             for workspace_name_in_display in &self.conf.workspaces_names {
                 for workspace_name in workspace_name_in_display {
-                    key_to_keycode(&self.xmodmap_pke, workspace_name).map ( |keycode|
-                        xcb::grab_key(&self.conn, false, screen.root(), mod_mask as u16, keycode, xcb::GRAB_MODE_ASYNC as u8, xcb::GRAB_MODE_ASYNC as u8)
-                    );
+                    key_to_keycode(&self.xmodmap_pke, workspace_name).map(|keycode| {
+                        xcb::grab_key(
+                            &self.conn,
+                            false,
+                            screen.root(),
+                            mod_mask as u16,
+                            keycode,
+                            xcb::GRAB_MODE_ASYNC as u8,
+                            xcb::GRAB_MODE_ASYNC as u8,
+                        )
+                    });
                 }
             }
             for custom_action_key in self.conf.custom_actions.keys() {
-                key_to_keycode(&self.xmodmap_pke, custom_action_key).map ( |keycode|
-                    xcb::grab_key(&self.conn, false, screen.root(), mod_mask as u16, keycode, xcb::GRAB_MODE_ASYNC as u8, xcb::GRAB_MODE_ASYNC as u8)
-                );
+                key_to_keycode(&self.xmodmap_pke, custom_action_key).map(|keycode| {
+                    xcb::grab_key(
+                        &self.conn,
+                        false,
+                        screen.root(),
+                        mod_mask as u16,
+                        keycode,
+                        xcb::GRAB_MODE_ASYNC as u8,
+                        xcb::GRAB_MODE_ASYNC as u8,
+                    )
+                });
             }
             for custom_action_key in self.conf.wm_actions.keys() {
-                key_to_keycode(&self.xmodmap_pke, custom_action_key).map ( |keycode|
-                    xcb::grab_key(&self.conn, false, screen.root(), mod_mask as u16, keycode, xcb::GRAB_MODE_ASYNC as u8, xcb::GRAB_MODE_ASYNC as u8)
-                );
+                key_to_keycode(&self.xmodmap_pke, custom_action_key).map(|keycode| {
+                    xcb::grab_key(
+                        &self.conn,
+                        false,
+                        screen.root(),
+                        mod_mask as u16,
+                        keycode,
+                        xcb::GRAB_MODE_ASYNC as u8,
+                        xcb::GRAB_MODE_ASYNC as u8,
+                    )
+                });
             }
         }
         for button in vec![1, 3] {
-            xcb::grab_button(&self.conn, false, screen.root(), (xcb::EVENT_MASK_BUTTON_PRESS | xcb::EVENT_MASK_BUTTON_RELEASE | xcb::EVENT_MASK_POINTER_MOTION) as u16, xcb::GRAB_MODE_ASYNC as u8, xcb::GRAB_MODE_ASYNC as u8, xcb::NONE, xcb::NONE, button as u8, mod_key as u16);
+            xcb::grab_button(
+                &self.conn,
+                false,
+                screen.root(),
+                (xcb::EVENT_MASK_BUTTON_PRESS
+                    | xcb::EVENT_MASK_BUTTON_RELEASE
+                    | xcb::EVENT_MASK_POINTER_MOTION) as u16,
+                xcb::GRAB_MODE_ASYNC as u8,
+                xcb::GRAB_MODE_ASYNC as u8,
+                xcb::NONE,
+                xcb::NONE,
+                button as u8,
+                mod_key as u16,
+            );
         }
-        xcb::change_window_attributes(&self.conn, screen.root(), &[(xcb::CW_EVENT_MASK, xcb::EVENT_MASK_SUBSTRUCTURE_NOTIFY as u32)]);
+        xcb::change_window_attributes(
+            &self.conn,
+            screen.root(),
+            &[(
+                xcb::CW_EVENT_MASK,
+                xcb::EVENT_MASK_SUBSTRUCTURE_NOTIFY as u32,
+            )],
+        );
         self.conn.flush();
     }
 
-    fn focus_unfocus(&mut self, window: &xcb::Window, do_focus: bool) -> Result<(), Box<dyn Error>> {
+    fn focus_unfocus(
+        &mut self,
+        window: &xcb::Window,
+        do_focus: bool,
+    ) -> Result<(), Box<dyn Error>> {
         let mut border_focus = false;
         if do_focus {
             xcb::set_input_focus(&self.conn, xcb::INPUT_FOCUS_PARENT as u8, *window, 0);
-            let workspace = self.workspaces.get_mut(&self.current_workspace).ok_or("workspace not found")?;
-            workspace.windows.iter().position(|x| x == window).map(|i| workspace.focus = i );
-            border_focus = !((workspace.windows.len() == 1 || workspace.layout == Layout::Monocle) && self.displays_geometries.len() == 1);
-            let net_active_window = xcb::intern_atom(&self.conn, false, "_NET_ACTIVE_WINDOW").get_reply()?.atom();
+            let workspace = self
+                .workspaces
+                .get_mut(&self.current_workspace)
+                .ok_or("workspace not found")?;
+            workspace
+                .windows
+                .iter()
+                .position(|x| x == window)
+                .map(|i| workspace.focus = i);
+            border_focus = !((workspace.windows.len() == 1 || workspace.layout == Layout::Monocle)
+                && self.displays_geometries.len() == 1);
+            let net_active_window = xcb::intern_atom(&self.conn, false, "_NET_ACTIVE_WINDOW")
+                .get_reply()?
+                .atom();
             let setup = self.conn.get_setup();
             let root = setup.roots().nth(0).ok_or("roots 0 not found")?.root();
             let data = vec![*window];
-            xproto::change_property(&self.conn, xcb::PROP_MODE_REPLACE as u8, root, net_active_window, xproto::ATOM_WINDOW, 32, &data[..]);
-
+            xproto::change_property(
+                &self.conn,
+                xcb::PROP_MODE_REPLACE as u8,
+                root,
+                net_active_window,
+                xproto::ATOM_WINDOW,
+                32,
+                &data[..],
+            );
         }
-        xcb::change_window_attributes(&self.conn, *window, &[
-            (xcb::CW_BORDER_PIXEL, 
-             if border_focus {
-                 self.conf.border.focus_color
-             } else {
-                 self.conf.border.normal_color
-             }
-            ),
-        ]);
+        xcb::change_window_attributes(
+            &self.conn,
+            *window,
+            &[(
+                xcb::CW_BORDER_PIXEL,
+                if border_focus {
+                    self.conf.border.focus_color
+                } else {
+                    self.conf.border.normal_color
+                },
+            )],
+        );
         Ok(())
     }
 
-
     fn run_wm_action(&mut self, key: &Key) -> Result<(), Box<dyn Error>> {
         let workspaces_names_by_display = self.conf.workspaces_names.clone();
-        let action = self.conf.wm_actions.get(&key.to_string()).ok_or("action not found")?;
-        let workspace = self.workspaces.get_mut(&self.current_workspace).ok_or("workspace not found")?;
+        let action = self
+            .conf
+            .wm_actions
+            .get(&key.to_string())
+            .ok_or("action not found")?;
+        let workspace = self
+            .workspaces
+            .get_mut(&self.current_workspace)
+            .ok_or("workspace not found")?;
         match action {
             Actions::CloseWindow => {
-                let window = workspace.windows.get(workspace.focus).ok_or("window not found")?;
-                let wm_delete_window = xcb::intern_atom(&self.conn, false, "WM_DELETE_WINDOW").get_reply()?.atom();
-                let wm_protocols = xcb::intern_atom(&self.conn, false, "WM_PROTOCOLS").get_reply()?.atom();
+                let window = workspace
+                    .windows
+                    .get(workspace.focus)
+                    .ok_or("window not found")?;
+                let wm_delete_window = xcb::intern_atom(&self.conn, false, "WM_DELETE_WINDOW")
+                    .get_reply()?
+                    .atom();
+                let wm_protocols = xcb::intern_atom(&self.conn, false, "WM_PROTOCOLS")
+                    .get_reply()?
+                    .atom();
                 let data = xcb::ClientMessageData::from_data32([
                     wm_delete_window,
                     xcb::CURRENT_TIME,
-                    0, 0, 0,
+                    0,
+                    0,
+                    0,
                 ]);
-                let ev = xcb::ClientMessageEvent::new(32, *window,
-                    wm_protocols, data);
+                let ev = xcb::ClientMessageEvent::new(32, *window, wm_protocols, data);
                 xcb::send_event(&self.conn, false, *window, xcb::EVENT_MASK_NO_EVENT, &ev);
                 self.conn.flush();
-            },
+            }
             Actions::SwitchWindow => {
                 if workspace.windows.len() > 0 {
                     workspace.focus = (workspace.focus + 1) % workspace.windows.len();
                 }
-            },
+            }
             Actions::ChangeLayout => {
                 workspace.layout = match workspace.layout {
                     Layout::BSPV => Layout::Monocle,
                     Layout::Monocle => Layout::BSPH,
                     Layout::BSPH => Layout::BSPV,
                 }
-            },
+            }
             Actions::ToggleGap => {
-               self.conf.with_gap =  !self.conf.with_gap;
-            },
+                self.conf.with_gap = !self.conf.with_gap;
+            }
         };
         for (display, workspaces_names) in workspaces_names_by_display.iter().enumerate() {
             if workspaces_names.contains(&self.current_workspace) {
-                let workspace = self.workspaces.get(&self.current_workspace).ok_or("workspace not found")?.clone();
+                let workspace = self
+                    .workspaces
+                    .get(&self.current_workspace)
+                    .ok_or("workspace not found")?
+                    .clone();
                 self.resize_workspace_windows(&workspace, display);
             }
         }
         Ok(())
     }
 
-
-
     fn get_str_property(&mut self, window: u32, name: &str) -> Option<String> {
-        let _net_wm_window_type = xcb::intern_atom(&self.conn, false, name).get_reply().unwrap().atom();
-        let cookie = xcb::get_property(&self.conn, false, window, _net_wm_window_type, xcb::ATOM_ANY, 0, 1024);
+        let _net_wm_window_type = xcb::intern_atom(&self.conn, false, name)
+            .get_reply()
+            .unwrap()
+            .atom();
+        let cookie = xcb::get_property(
+            &self.conn,
+            false,
+            window,
+            _net_wm_window_type,
+            xcb::ATOM_ANY,
+            0,
+            1024,
+        );
         if let Ok(reply) = cookie.get_reply() {
             Some(std::str::from_utf8(reply.value()).unwrap().to_string())
         } else {
@@ -454,11 +646,12 @@ impl UmberWM {
     fn get_atom_property(&mut self, id: u32, name: &str) -> Result<u32, Box<dyn Error>> {
         let window: xproto::Window = id;
         let ident = xcb::intern_atom(&self.conn, true, name).get_reply()?.atom();
-        let reply = xproto::get_property(&self.conn, false, window, ident, xproto::ATOM_ATOM, 0, 1024).get_reply()?;
+        let reply =
+            xproto::get_property(&self.conn, false, window, ident, xproto::ATOM_ATOM, 0, 1024)
+                .get_reply()?;
         if reply.value_len() <= 0 {
             Ok(42)
-        }
-        else {
+        } else {
             Ok(reply.value()[0])
         }
     }
@@ -468,87 +661,149 @@ impl UmberWM {
             for workspace_window in &workspace.windows {
                 if &window == workspace_window {
                     /* the window already exist in a workspace */
-                    return Ok(())
+                    return Ok(());
                 }
             }
         }
-        let wm_class = self.get_str_property(window, "WM_CLASS").ok_or("failed getting wm class")?;
+        let wm_class = self
+            .get_str_property(window, "WM_CLASS")
+            .ok_or("failed getting wm class")?;
         let window_type = self.get_atom_property(window, "_NET_WM_WINDOW_TYPE")?;
-        let window_types = window_types_from_list(&self.conn, &vec![
-            "menu".to_string(),
-            "popup_menu".to_string(),
-            "dropdown_menu".to_string(),
-            "tooltip".to_string(),
-
-            "utility".to_string(),
-            "notification".to_string(),
-            "toolbar".to_string(),
-            "splash".to_string(),
-            "dialog".to_string(),
-            "dock".to_string(),
-            //"dnd".to_string(),
-        ]);
-        let wm_class : Vec<&str> = wm_class.split('\0').collect();
-        println!("UGUU: {} {} {}", window, xcb::get_atom_name(&self.conn, window_type).get_reply()?.name(), wm_class.join("-"));
+        let window_types = window_types_from_list(
+            &self.conn,
+            &vec![
+                "menu".to_string(),
+                "popup_menu".to_string(),
+                "dropdown_menu".to_string(),
+                "tooltip".to_string(),
+                "utility".to_string(),
+                "notification".to_string(),
+                "toolbar".to_string(),
+                "splash".to_string(),
+                "dialog".to_string(),
+                "dock".to_string(),
+                //"dnd".to_string(),
+            ],
+        );
+        let wm_class: Vec<&str> = wm_class.split('\0').collect();
+        println!(
+            "UGUU: {} {} {}",
+            window,
+            xcb::get_atom_name(&self.conn, window_type)
+                .get_reply()?
+                .name(),
+            wm_class.join("-")
+        );
         if window_types.contains(&window_type) {
-            return Ok(())
+            return Ok(());
         } else {
-            if "_KDE_NET_WM_WINDOW_TYPE_OVERRIDE" == xcb::get_atom_name(&self.conn, window_type).get_reply()?.name() /*|| xcb::get_atom_name(&self.conn, window_type).get_reply()?.name() == "WM_ZOOM_HINTS"*/ {
-                return Ok(())
+            if "_KDE_NET_WM_WINDOW_TYPE_OVERRIDE"
+                == xcb::get_atom_name(&self.conn, window_type)
+                    .get_reply()?
+                    .name()
+            /*|| xcb::get_atom_name(&self.conn, window_type).get_reply()?.name() == "WM_ZOOM_HINTS"*/
+            {
+                return Ok(());
             }
         }
         if wm_class.len() != 0 {
             for i in 0..wm_class.len() {
-                if wm_class[i] == "xscreensaver" || self.conf.ignore_classes.contains(&wm_class[i].to_string()) { 
-                    return Ok(())
+                if wm_class[i] == "xscreensaver"
+                    || self.conf.ignore_classes.contains(&wm_class[i].to_string())
+                {
+                    return Ok(());
                 }
             }
         }
         match self.workspaces.get_mut(&self.current_workspace) {
             Some(workspace) => {
                 if !workspace.windows.contains(&window) {
-                    if wm_class.len() != 0 && self.conf.float_classes.contains(&wm_class[0].to_string()) && !self.float_windows.contains(&window) { 
+                    if wm_class.len() != 0
+                        && self.conf.float_classes.contains(&wm_class[0].to_string())
+                        && !self.float_windows.contains(&window)
+                    {
                         self.float_windows.push(window);
                     }
                     workspace.windows.push(window);
                     workspace.focus = workspace.windows.len() - 1;
                     let workspace2 = workspace.clone();
                     let workspaces_names_by_display = self.conf.workspaces_names.clone();
-                    for (display, workspaces_names) in workspaces_names_by_display.iter().enumerate() {
+                    for (display, workspaces_names) in
+                        workspaces_names_by_display.iter().enumerate()
+                    {
                         if workspaces_names.contains(&self.current_workspace) {
                             self.resize_workspace_windows(&workspace2, display);
                         }
                     }
                 }
-            },
-            None => {
-            },
+            }
+            None => {}
         }
-        xcb::change_window_attributes(&self.conn, window, &[(xcb::CW_EVENT_MASK, xcb::EVENT_MASK_ENTER_WINDOW | xcb::EVENT_MASK_LEAVE_WINDOW)]);
+        xcb::change_window_attributes(
+            &self.conn,
+            window,
+            &[(
+                xcb::CW_EVENT_MASK,
+                xcb::EVENT_MASK_ENTER_WINDOW | xcb::EVENT_MASK_LEAVE_WINDOW,
+            )],
+        );
         Ok(())
     }
 
     fn resize_window(&mut self, event: &xcb::MotionNotifyEvent) -> Result<(), Box<dyn Error>> {
         let mouse_move_start = self.mouse_move_start.clone().ok_or("no mouse move start")?;
-        let attr = self.button_press_geometry.clone().ok_or("no button press geometry")?;
+        let attr = self
+            .button_press_geometry
+            .clone()
+            .ok_or("no button press geometry")?;
         let xdiff = event.root_x() - mouse_move_start.root_x;
         let ydiff = event.root_y() - mouse_move_start.root_y;
-        let x = attr.0 as i32 + if mouse_move_start.detail == 1 { xdiff as i32 } else { 0 };
-        let y = attr.1 as i32 + if mouse_move_start.detail == 1 { ydiff as i32 } else { 0 };
-        let width = max(1, attr.2 as i32 + if mouse_move_start.detail == 3 { xdiff as i32 } else { 0 });
-        let height = max(1, attr.3 as i32 + if mouse_move_start.detail == 3 { ydiff as i32 } else { 0 });
-        xcb::configure_window(&self.conn, mouse_move_start.child, &[
-                            (xcb::CONFIG_WINDOW_X as u16, x as u32),
-                            (xcb::CONFIG_WINDOW_Y as u16, y as u32),
-                            (xcb::CONFIG_WINDOW_WIDTH as u16, width as u32),
-                            (xcb::CONFIG_WINDOW_HEIGHT as u16, height as u32),
-                        ]);
+        let x = attr.0 as i32
+            + if mouse_move_start.detail == 1 {
+                xdiff as i32
+            } else {
+                0
+            };
+        let y = attr.1 as i32
+            + if mouse_move_start.detail == 1 {
+                ydiff as i32
+            } else {
+                0
+            };
+        let width = max(
+            1,
+            attr.2 as i32
+                + if mouse_move_start.detail == 3 {
+                    xdiff as i32
+                } else {
+                    0
+                },
+        );
+        let height = max(
+            1,
+            attr.3 as i32
+                + if mouse_move_start.detail == 3 {
+                    ydiff as i32
+                } else {
+                    0
+                },
+        );
+        xcb::configure_window(
+            &self.conn,
+            mouse_move_start.child,
+            &[
+                (xcb::CONFIG_WINDOW_X as u16, x as u32),
+                (xcb::CONFIG_WINDOW_Y as u16, y as u32),
+                (xcb::CONFIG_WINDOW_WIDTH as u16, width as u32),
+                (xcb::CONFIG_WINDOW_HEIGHT as u16, height as u32),
+            ],
+        );
         Ok(())
     }
 
     fn destroy_window(&mut self, window: u32) {
         self.float_windows.retain(|&x| x != window);
-        let mut workspace2 : Option<Workspace> = None;
+        let mut workspace2: Option<Workspace> = None;
         for (_, workspace) in &mut self.workspaces {
             if workspace.windows.contains(&window) {
                 workspace.windows.retain(|&x| x != window);
@@ -566,8 +821,11 @@ impl UmberWM {
             }
         }
 
-        workspace2.map(|workspace| { 
-            workspace.windows.get(workspace.focus).map(|previous_window| self.focus_unfocus(previous_window, true));
+        workspace2.map(|workspace| {
+            workspace
+                .windows
+                .get(workspace.focus)
+                .map(|previous_window| self.focus_unfocus(previous_window, true));
             self.resize_workspace_windows(&workspace, dis);
         });
     }
@@ -578,107 +836,109 @@ impl UmberWM {
                 Some(event) => {
                     let r = event.response_type();
                     if r == xcb::MAP_NOTIFY as u8 {
-                        let map_notify : &xcb::MapNotifyEvent = unsafe {
-                            xcb::cast_event(&event)
-                        };
+                        let map_notify: &xcb::MapNotifyEvent = unsafe { xcb::cast_event(&event) };
                         let _ = self.setup_new_window(map_notify.window());
                     }
                     if r == self.randr_base + randr::NOTIFY {
                         self.displays_geometries = self.get_displays_geometries().unwrap();
                     }
                     if r == xcb::DESTROY_NOTIFY as u8 {
-                        let map_notify : &xcb::DestroyNotifyEvent = unsafe {
-                            xcb::cast_event(&event)
-                        };
+                        let map_notify: &xcb::DestroyNotifyEvent =
+                            unsafe { xcb::cast_event(&event) };
                         self.destroy_window(map_notify.window());
-                    }
-                    else if r == xcb::BUTTON_PRESS as u8 {
-                        let event : &xcb::ButtonPressEvent = unsafe {
-                            xcb::cast_event(&event)
-                        };
+                    } else if r == xcb::BUTTON_PRESS as u8 {
+                        let event: &xcb::ButtonPressEvent = unsafe { xcb::cast_event(&event) };
                         match xcb::get_geometry(&self.conn, event.child()).get_reply() {
-                            Ok(geometry) => {self.button_press_geometry = Some(
-                                Geometry(geometry.x() as u32, geometry.y() as u32, geometry.width() as u32, geometry.height() as u32)
-                                );},
-                            Err(_) => {},
+                            Ok(geometry) => {
+                                self.button_press_geometry = Some(Geometry(
+                                    geometry.x() as u32,
+                                    geometry.y() as u32,
+                                    geometry.width() as u32,
+                                    geometry.height() as u32,
+                                ));
+                            }
+                            Err(_) => {}
                         }
-                        self.mouse_move_start = Some(MouseMoveStart{
+                        self.mouse_move_start = Some(MouseMoveStart {
                             root_x: event.root_x(),
                             root_y: event.root_y(),
                             child: event.child(),
                             detail: event.detail(),
                         });
-                    }
-                    else if r == xcb::MOTION_NOTIFY as u8 {
-                        let event : &xcb::MotionNotifyEvent = unsafe {
-                            xcb::cast_event(&event)
-                        };
+                    } else if r == xcb::MOTION_NOTIFY as u8 {
+                        let event: &xcb::MotionNotifyEvent = unsafe { xcb::cast_event(&event) };
                         let _ = self.resize_window(event);
-                    }
-                    else if r == xcb::LEAVE_NOTIFY as u8 {
-                        let event : &xcb::LeaveNotifyEvent = unsafe {
-                            xcb::cast_event(&event)
-                        };
-                        let _= self.focus_unfocus(&event.event(), false);
-                    }
-                    else if r == xcb::ENTER_NOTIFY as u8 {
-                        let event : &xcb::EnterNotifyEvent = unsafe {
-                            xcb::cast_event(&event)
-                        };
+                    } else if r == xcb::LEAVE_NOTIFY as u8 {
+                        let event: &xcb::LeaveNotifyEvent = unsafe { xcb::cast_event(&event) };
+                        let _ = self.focus_unfocus(&event.event(), false);
+                    } else if r == xcb::ENTER_NOTIFY as u8 {
+                        let event: &xcb::EnterNotifyEvent = unsafe { xcb::cast_event(&event) };
                         let _ = self.focus_unfocus(&event.event(), true);
-                    }
-                    else if r == xcb::BUTTON_RELEASE as u8 {
+                    } else if r == xcb::BUTTON_RELEASE as u8 {
                         self.mouse_move_start = None;
-                    }
-                    else if r == xcb::KEY_PRESS as u8 {
-                        let key_press : &xcb::KeyPressEvent = unsafe {
-                            xcb::cast_event(&event)
-                        };
+                    } else if r == xcb::KEY_PRESS as u8 {
+                        let key_press: &xcb::KeyPressEvent = unsafe { xcb::cast_event(&event) };
                         let keycode = key_press.detail();
                         match &keycode_to_key(&self.xmodmap_pke, keycode) {
                             Some(key) => {
-                                let workspaces_names_by_display = self.conf.workspaces_names.clone();
-                                for (display, workspaces_names) in workspaces_names_by_display.iter().enumerate() {
+                                let workspaces_names_by_display =
+                                    self.conf.workspaces_names.clone();
+                                for (display, workspaces_names) in
+                                    workspaces_names_by_display.iter().enumerate()
+                                {
                                     if workspaces_names.contains(key) {
-                                        match change_workspace(&self.conn, &mut self.workspaces, self.current_workspace.to_string(), key.to_string(), (key_press.state() as u32 ) & xcb::MOD_MASK_SHIFT != 0, 
-                                            workspaces_names.contains(&self.current_workspace) || display >= self.displays_geometries.len() || self.previous_display >= self.displays_geometries.len()) {
-                                            Ok(workspace) => { 
+                                        match change_workspace(
+                                            &self.conn,
+                                            &mut self.workspaces,
+                                            self.current_workspace.to_string(),
+                                            key.to_string(),
+                                            (key_press.state() as u32) & xcb::MOD_MASK_SHIFT != 0,
+                                            workspaces_names.contains(&self.current_workspace)
+                                                || display >= self.displays_geometries.len()
+                                                || self.previous_display
+                                                    >= self.displays_geometries.len(),
+                                        ) {
+                                            Ok(workspace) => {
                                                 self.previous_display = display;
                                                 self.current_workspace = workspace;
-                                                let workspace = self.workspaces.get(&self.current_workspace).ok_or("workspace not found").unwrap().clone();
+                                                let workspace = self
+                                                    .workspaces
+                                                    .get(&self.current_workspace)
+                                                    .ok_or("workspace not found")
+                                                    .unwrap()
+                                                    .clone();
                                                 self.resize_workspace_windows(&workspace, display);
-                                                let actual_display = if display >= self.displays_geometries.len() {
-                                                    self.displays_geometries.len() - 1
-                                                }
-                                                else {
-                                                    display
-                                                };
-                                                self.conf.events_callbacks.on_change_workspace.as_ref().map ( |callback|
-                                                    callback(key.to_string(), actual_display)
-                                                );
-                                            },
-                                            Err(_) => {},
+                                                let actual_display =
+                                                    if display >= self.displays_geometries.len() {
+                                                        self.displays_geometries.len() - 1
+                                                    } else {
+                                                        display
+                                                    };
+                                                self.conf
+                                                    .events_callbacks
+                                                    .on_change_workspace
+                                                    .as_ref()
+                                                    .map(|callback| {
+                                                        callback(key.to_string(), actual_display)
+                                                    });
+                                            }
+                                            Err(_) => {}
                                         };
                                     }
                                 }
                                 if self.conf.wm_actions.contains_key(&key.to_string()) {
                                     let _ = self.run_wm_action(&key);
-                                }
-                                else if self.conf.custom_actions.contains_key(&key.to_string()) {
+                                } else if self.conf.custom_actions.contains_key(&key.to_string()) {
                                     match self.conf.custom_actions.get(&key.to_string()) {
-                                        Some(action) => {
-                                            action()
-                                        },
-                                        None => {},
+                                        Some(action) => action(),
+                                        None => {}
                                     }
                                 }
-                            },
-                            None => {
-                            },
-
+                            }
+                            None => {}
                         }
                     }
-                },
+                }
                 None => {}
             }
             self.conn.flush();
@@ -688,13 +948,26 @@ impl UmberWM {
 
 pub fn umberwm(conf: Conf) -> UmberWM {
     let (conn, _) = xcb::Connection::connect(None).unwrap();
-    let conf_workspaces_flatten : Vec<Key> = conf.workspaces_names.clone().into_iter().flatten().collect();
-    let workspaces = conf_workspaces_flatten.into_iter().map( |x|
-            (x, Workspace {
-                layout: Layout::BSPV,
-                windows: vec![],
-                focus: 0,
-        })).into_iter().collect();
+    let conf_workspaces_flatten: Vec<Key> = conf
+        .workspaces_names
+        .clone()
+        .into_iter()
+        .flatten()
+        .collect();
+    let workspaces = conf_workspaces_flatten
+        .into_iter()
+        .map(|x| {
+            (
+                x,
+                Workspace {
+                    layout: Layout::BSPV,
+                    windows: vec![],
+                    focus: 0,
+                },
+            )
+        })
+        .into_iter()
+        .collect();
     let xmodmap_pke = xmodmap_pke().unwrap();
     let current_workspace = conf.workspaces_names.get(0).unwrap()[0].to_string();
     let mut wm = UmberWM {


### PR DESCRIPTION
Move some deeply nested code out into dedicated functions, such as `handle_key_press()`, `handle_button_press()`, `resize_bsp()` and `resize_monocle()`. This makes a lot of logic easier to follow, and also reduces indentation several levels.

Replace single arm `match` statements with `if let`, e.g.:
```rust
match x {
    Some(y) => do_something(y),
    None => None
}
```
becomes
```rust
if let Some(y) = x {
    do_something(y);
}
```
This removes a level of indentation.

Replace `let _ = x` with `x.ok()`. No reason for this other than I think it looks better.

This PR supersedes #21 (it is based on top of the edits in that PR).