### PR TITLE
Add custom errors and logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["GUI"]
 [dependencies]
 regex = "1.3"
 miniserde = "0.1"
+thiserror = "1.0.24"
 [dependencies.xcb]
 version = "0.9"
 features = ["randr"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,52 @@
+use std::fmt::Display;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Workspace not found")]
+    WorkspaceNotFound,
+    #[error("Action not found")]
+    ActionNotFound,
+    #[error("No screens found")]
+    NoScreensFound,
+    #[error("Window not found")]
+    WindowNotFound,
+    #[error("Failed to get window manager class")]
+    FailedToGetWmClass,
+    #[error("No mouse move start")]
+    NoMouseMoveStart,
+    #[error("No butten press geometry")]
+    NoButtonPressGeometry,
+    #[error("Failed to deserialize from JSON: {0}")]
+    FailedToDeserializeFromJson(String),
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+    #[error(transparent)]
+    RegexError(#[from] regex::Error),
+    #[error(transparent)]
+    FromUtf8Error(#[from] std::string::FromUtf8Error),
+    #[error(transparent)]
+    XcbGenericError(#[from] xcb::GenericError),
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub trait LogError<T> {
+    /// Converts from `Result<T, E>` to `Option<T>`, logging errors.
+    ///
+    /// Converts `self` into an `Option<T>`, consuming `self`, and logging the error, if any, to
+    /// `STDERR`.
+    fn log(self) -> Option<T>;
+}
+
+impl<T, E: Display> LogError<T> for Result<T, E> {
+    fn log(self) -> Option<T> {
+        match self {
+            Ok(x) => Some(x),
+            Err(e) => {
+                eprintln!("{}", e);
+                None
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds the `error` module which defines `Error`, `Result` and `LogError`.

`LogError` is a trait that lets us add the `log()` method to `Result`, which behaves just like `ok()` (converts `Result<T, E>` -> `Option<T>`), except that it logs errors if there are any.

Replaces all occurrences of `.ok()` with `.log()`, which should help us find errors that are currently getting silently ignored.