### PR TITLE
Enable logging

### DIFF
--- a/umberwm-start
+++ b/umberwm-start
@@ -2,7 +2,7 @@
 
 # Custom actions go here
 
-mkdir -p $HOME/.local/share/umberwm
+mkdir -p "$HOME"/.local/share/umberwm
 
 while true; do
   umberwm &>> $HOME/.local/share/umberwm/umberwm.log

--- a/umberwm-start
+++ b/umberwm-start
@@ -2,8 +2,10 @@
 
 # Custom actions go here
 
+mkdir -p $HOME/.local/share/umberwm
+
 while true; do
-  umberwm
+  umberwm &>> $HOME/.local/share/umberwm/umberwm.log
   # If umberwm returns exit code 123, restart, otherwise quit.
   [ $? -ne 123 ] && break
 done

--- a/umberwm-start
+++ b/umberwm-start
@@ -5,7 +5,7 @@
 mkdir -p "$HOME"/.local/share/umberwm
 
 while true; do
-  umberwm &>> $HOME/.local/share/umberwm/umberwm.log
+  umberwm &>> "$HOME"/.local/share/umberwm/umberwm.log 2>&1
   # If umberwm returns exit code 123, restart, otherwise quit.
   [ $? -ne 123 ] && break
 done


### PR DESCRIPTION
`umberwm-start` ensures the directory `~/.local/share/umberwm` exists and logs all the output of `umberwm` to `~/.local/share/umberwm/umberwm.log`.