### PR TITLE
Remove redundant 2>&1

### DIFF
--- a/umberwm-start
+++ b/umberwm-start
@@ -5,7 +5,7 @@
 mkdir -p "$HOME"/.local/share/umberwm
 
 while true; do
-  umberwm &>> "$HOME"/.local/share/umberwm/umberwm.log 2>&1
+  umberwm &>> "$HOME"/.local/share/umberwm/umberwm.log
   # If umberwm returns exit code 123, restart, otherwise quit.
   [ $? -ne 123 ] && break
 done


### PR DESCRIPTION
`&>>` redirects both `stdout` and `stderr`, so `2>&1` is redundant here.