### PR TITLE
🌄  add support for overlay windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "umberwm"
-version = "0.0.22"
+version = "0.0.23"
 authors = ["yazgoo <yazgoo@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,12 +132,14 @@ fn main() {
             "rofi",
             "xscreensaver",
             "quickmarks",
-            "discover-overlay",
-            "Discover-overlay",
         ]
         .into_iter()
         .map(|x| x.to_string())
         .collect(),
+        overlay_classes: vec!["discover-overlay", "Discover-overlay"]
+            .into_iter()
+            .map(|x| x.to_string())
+            .collect(),
         events_callbacks: EventsCallbacks {
             // Custom callback will be called when we change a workspace.
             on_change_workspace: Some(Box::new(|workspace, display| {


### PR DESCRIPTION
🌄  add support for overlay windows

Add support for overlay windows like [discover-overlay](https://github.com/trigg/Discover).
Like float windows, they won't be modified in term of size + position.
Unlike float windows, they should be shown on all workspaces, always above all windows.