### PR TITLE
🌠 add sticky windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "umberwm"
-version = "0.0.27"
+version = "0.0.28"
 authors = ["yazgoo <yazgoo@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,13 +20,13 @@ pub enum Error {
     #[error("Failed to deserialize from JSON: {0}")]
     FailedToDeserializeFromJson(String),
     #[error(transparent)]
-    SerdeError(#[from] ron::error::Error),
+    Error(#[from] ron::error::Error),
     #[error(transparent)]
-    IoError(#[from] std::io::Error),
+    Io(#[from] std::io::Error),
     #[error(transparent)]
-    FromUtf8Error(#[from] std::string::FromUtf8Error),
+    FromUtf8(#[from] std::string::FromUtf8Error),
     #[error(transparent)]
-    XcbGenericError(#[from] xcb::GenericError),
+    XcbGeneric(#[from] xcb::GenericError),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,7 @@ fn main() {
                 .into_iter()
                 .map(|x| x.to_string())
                 .collect(),
-
+            sticky_classes: vec![].into_iter().collect(),
             // Defines if there are gaps between windows (assuming `gap` is not 0 in `display_borders`)
             with_gap: false,
             custom_commands: vec![

--- a/src/model.rs
+++ b/src/model.rs
@@ -126,6 +126,8 @@ pub struct SerializableConf {
     pub float_classes: Vec<String>,
     /// will not resize and display on top windows with this wm_class
     pub overlay_classes: Vec<String>,
+    /// will stick these window classes to theses workspace on window open
+    pub sticky_classes: HashMap<String, WorkspaceName>,
     /// should we enable gaps (as defined in border) on startup
     pub with_gap: bool,
     /// run commands on given keys

--- a/src/umberwm_impl.rs
+++ b/src/umberwm_impl.rs
@@ -21,7 +21,7 @@ use xcb::xproto;
 impl UmberWm {
     fn resize_workspace_windows(&mut self, workspace: &Workspace, mut display: usize) {
         let mut non_float_windows = workspace.windows.clone();
-        non_float_windows.retain(|w| !self.float_windows.contains(&w));
+        non_float_windows.retain(|w| !self.float_windows.contains(w));
         let count = non_float_windows.len();
         if count == 0 || self.displays_geometries.is_empty() {
             return;

--- a/src/umberwm_impl/helpers.rs
+++ b/src/umberwm_impl/helpers.rs
@@ -23,7 +23,7 @@ pub fn get_displays_geometries(conn: &xcb::Connection) -> Result<Vec<Geometry>> 
     let screen = setup.roots().next().unwrap();
     let window_dummy = conn.generate_id();
     xcb::create_window(
-        &conn,
+        conn,
         0,
         window_dummy,
         screen.root(),
@@ -36,13 +36,13 @@ pub fn get_displays_geometries(conn: &xcb::Connection) -> Result<Vec<Geometry>> 
         0,
         &[],
     );
-    let screen_res_cookie = randr::get_screen_resources(&conn, window_dummy);
+    let screen_res_cookie = randr::get_screen_resources(conn, window_dummy);
     let screen_res_reply = screen_res_cookie.get_reply().unwrap();
     let crtcs = screen_res_reply.crtcs();
 
     let mut crtc_cookies = Vec::with_capacity(crtcs.len());
     for crtc in crtcs {
-        crtc_cookies.push(randr::get_crtc_info(&conn, *crtc, 0));
+        crtc_cookies.push(randr::get_crtc_info(conn, *crtc, 0));
     }
 
     let mut result = Vec::new();
@@ -145,7 +145,7 @@ pub fn window_types_from_list(conn: &xcb::Connection, types_names: &[String]) ->
         .iter()
         .map(|x| {
             let name = format!("_NET_WM_WINDOW_TYPE_{}", x.to_uppercase());
-            let res = xcb::intern_atom(&conn, true, name.as_str())
+            let res = xcb::intern_atom(conn, true, name.as_str())
                 .get_reply()
                 .map(|x| x.atom());
             res.log()


### PR DESCRIPTION
🌠 add sticky windows

Add `sticky_classes`, so that when a window of this class appears
(i.e. is mapped), it is created under the specified workspace.

fixes https://github.com/yazgoo/umberwm/issues/46